### PR TITLE
fix: remove trailing slash

### DIFF
--- a/covidfaq/routers/answers.py
+++ b/covidfaq/routers/answers.py
@@ -32,7 +32,7 @@ class ElasticResults(BaseModel):
     sec_results: Optional[List[SecResults]]
 
 
-@router.get("/answers/", response_model=Answers)
+@router.get("/answers", response_model=Answers)
 def answers(request: Request, question: str):
 
     language = request.headers.get("Accept-Language")


### PR DESCRIPTION
It fixes the HTTP 307 and remove the needs to add a trailing slash in
the frontend.