### PR TITLE
feat: save html and retrieve headers hierarchically

### DIFF
--- a/covidfaq/scrape/quebec-sites.yaml
+++ b/covidfaq/scrape/quebec-sites.yaml
@@ -28,7 +28,7 @@ quebec-fr: &qfr
 
     - method: nesting
       parent: ".frame, .frame-default, .frame-type-textmedia, .frame-layout-0"
-      title: "h2, h3, h4"
+      title: "h1, h2, h3, h4"
       body: ".ce-bodytext"
       exclude:
         title: "^(Avis|Notice)$"

--- a/covidfaq/scrape/scrape.py
+++ b/covidfaq/scrape/scrape.py
@@ -178,7 +178,7 @@ def extract_sections(url, info, cfg, translated=False):
 
 
 
-def run(yaml_filename, outdir, formatting='old', site=None):
+def run(yaml_filename, outdir='covidfaq/scrape', formatting='old', site=None):
     """Scrape websites for information."""
 
     with open(yaml_filename, 'r') as stream:

--- a/covidfaq/scrape/scrape.py
+++ b/covidfaq/scrape/scrape.py
@@ -422,8 +422,9 @@ def run():
             urlinfo["urlkey"] = f"{sitename}-{urlinfo['urlkey']}"
             info = {**sitecfg["info"], **urlinfo, "time": now, "url": url}
             result, soup = extract_sections(url, info, sitecfg)
-            results += result
-            soups.append(soup)
+            if result:
+                results += result
+                soups.append(soup)
 
     if format == "old":
         outdir = out or "covidfaq/scrape"

--- a/covidfaq/scrape/scrape.py
+++ b/covidfaq/scrape/scrape.py
@@ -218,10 +218,6 @@ def run(yaml_filename, outdir="covidfaq/scrape", formatting="old", site=None):
             filename_html = os.path.join(outdir, filename + ".html")
             soup_to_html(filename_html, soup)
 
-    elif formatting == "new":
-        outfile = out or "scrape_results.json"
-        page_to_json(results, outfile)
-
     else:
         print(f"Unknown format: {format}")
         sys.exit(1)

--- a/covidfaq/scrape/scrape.py
+++ b/covidfaq/scrape/scrape.py
@@ -84,11 +84,11 @@ def rule_nesting(soup, info, url, rule):
                 nest_level = int(title.name[1]) - 1
                 if nest_level >= prev_nest_level:
                     nested_titles[nest_level] = raw_title
-                    prev_nest_level = nest_level
                 else:
                     nested_titles[nest_level] = raw_title
                     for n in range(nest_level+1, len(nested_titles)):
                         nested_titles[n] = ''
+                prev_nest_level = nest_level
 
         if exclude["title"] and re.search(exclude["title"], raw_title):
             continue

--- a/covidfaq/scrape/scrape.py
+++ b/covidfaq/scrape/scrape.py
@@ -1,7 +1,5 @@
-import json
-import yaml
 import argparse
-from yaml import load
+import json
 import os
 import re
 import sys
@@ -12,7 +10,9 @@ from urllib.parse import urljoin
 import bs4
 import requests
 import structlog
+import yaml
 from bs4 import BeautifulSoup
+from yaml import load
 
 log = structlog.get_logger(__name__)
 

--- a/covidfaq/scrape/scrape.py
+++ b/covidfaq/scrape/scrape.py
@@ -178,9 +178,11 @@ def extract_sections(url, info, cfg, translated=False):
 
 
 
-def run(sites, outdir, formatting='old', site=None):
+def run(yaml_filename, outdir, formatting='old', site=None):
     """Scrape websites for information."""
 
+    with open(yaml_filename, 'r') as stream:
+        sites = load(stream, Loader=yaml.FullLoader)
     now = str(datetime.now())
 
     results = []
@@ -233,7 +235,5 @@ if __name__ == "__main__":
     parser.add_argument("--sites", help="list of sites to scrape", required=True)
     parser.add_argument("--outdir", help="where to save scrapes", default='covidfaq/scrape')
     args = parser.parse_args()
-    with open(args.sites, 'r') as stream:
-        sites = load(stream, Loader=yaml.FullLoader)
 
-    run(sites, args.outdir)
+    run(args.sites, args.outdir)

--- a/covidfaq/scrape/scrape.py
+++ b/covidfaq/scrape/scrape.py
@@ -31,108 +31,6 @@ def page_to_json(page_contents, fname):
     with open(fname, "w", encoding="utf-8") as fp:
         json.dump(page_contents, fp, indent=4, ensure_ascii=False)
 
-
-def get_page_contents(URL):
-    """Scrape the contents based on the h2 headers and structure they use for a web page.
-
-    URL: string, absolute URL to the page
-
-    returns
-    ---
-    page_contents: dict, with key=subject, value=list of all paragraphs
-    """
-
-    page = requests.get(URL)
-    soup = BeautifulSoup(page.content, "html.parser")
-    page_contents = {"document_URL": URL}
-
-    # Extract top page warnings, if any
-    warnings = soup.find_all(
-        class_="frame frame-avisExclam frame-type-textmedia frame-layout-0"
-    )
-    if warnings:
-        #  warnings_text = [warning.get_text() for warning in warnings if warnings]
-        warnings_text = [warnings[0].get_text()]
-        warnings_html = warnings[0].prettify()
-
-        page_contents["warnings"] = {
-            "plaintext": warnings_text,
-            "html": warnings_html,
-            "URL": URL,
-        }
-
-    # Look for subjects and split them by header
-    subjects = soup.find_all(
-        class_="frame frame-default frame-type-textmedia frame-layout-0"
-    )
-
-    page_contents = handle_subjects(URL, page_contents, subjects)
-
-    # a panel usually contains the answer to a question
-    # a panel contains both the question and the answer
-    all_panels = soup.find_all(class_="panel panel-default")
-    if all_panels:
-        for panel in all_panels:
-            question = panel.find(class_="accordion-toggle")
-            answer = panel.find(class_="ce-bodytext")
-
-            if question and answer:
-                question_str = question.get_text()
-                answer_str = [answer.get_text()]
-                answer_html = [answer.prettify()]
-
-                page_contents[question_str] = {
-                    "URL": URL,
-                    "html": answer_html,
-                    "plaintext": answer_str,
-                }
-
-    return page_contents
-
-
-def handle_subjects(URL, page_contents, subjects):
-    for sub in subjects:
-        # Look for headers in each subject
-        raw_title = None
-        if sub.find("h2"):
-            raw_title = sub.find("h2").contents[0]
-        elif sub.find("h3"):
-            raw_title = sub.find("h3").contents[0]
-        elif sub.find("h4"):
-            raw_title = sub.find("h4").contents[0]
-        if raw_title:
-            title = " ".join(raw_title.split())
-            # Extract the text from a header block
-            if sub.find(class_="ce-bodytext"):
-                sub_text = []
-                sub_html = sub.find(class_="ce-bodytext")
-                for text in sub_html.contents:
-                    sub_text.append(text.get_text())
-                if title not in ["Avis", "Notice"]:  # This is on every page
-                    #  sub_contents['plaintext'] = sub_text
-                    #  sub_contents['html'] = sub_html.prettify()
-                    #  sub_contents['URL'] = URL
-                    page_contents[title] = {
-                        "plaintext": sub_text,
-                        "html": sub_html.prettify(),
-                        "URL": URL,
-                    }
-
-    return page_contents
-
-
-def get_english_page(URL, base_url="https://www.quebec.ca"):
-    """Get the english page associated to the french page"""
-
-    page = requests.get(URL)
-    soup = BeautifulSoup(page.content, "html.parser")
-    # The english translation link is the first link in an object called listePiv
-    en_href = soup.find(class_="listePiv").find_all("a")[0].get("href")
-    en_URL = base_url + en_href
-
-    return en_URL
-
-
 def page_to_md(page_contents, page_url, response_filename, nlu_filename):
     section_title = page_url.rsplit("/")[-2]
 
@@ -157,165 +55,58 @@ def page_to_md(page_contents, page_url, response_filename, nlu_filename):
             f.write("\n")
 
 
-def get_faq_contents(faq_URL):
-
-    page = requests.get(faq_URL)
-    soup = BeautifulSoup(page.content, "html.parser")
-
-    faq_contents = {"document_URL": faq_URL}
-    all_panels = soup.find_all(class_="panel panel-default")
-
-    # a panel contains both the question and the answer
-    for panel in all_panels:
-        question = panel.find(class_="accordion-toggle")
-        answer = panel.find(class_="ce-bodytext")
-
-        if question and answer:
-            question_str = question.get_text()
-            answer_str = [answer.get_text()]
-            answer_html = [answer.prettify()]
-
-            faq_contents[question_str] = {
-                "URL": faq_URL,
-                "html": answer_html,
-                "plaintext": answer_str,
-            }
-
-    return faq_contents
-
-
-def get_mainpage_contents(mainpage_URL):
-
-    page = requests.get(mainpage_URL)
-    soup = BeautifulSoup(page.content, "html.parser")
-    page_contents = {"document_URL": mainpage_URL}
-
-    warnings = soup.find_all(class_="alert alert-warning")
-    if warnings:
-        #  warnings_text = [warning.get_text() for warning in warnings if warnings]
-        warnings_text = [warnings[0].get_text()]
-        warnings_html = warnings[0].prettify()
-
-        page_contents["warnings"] = {
-            "plaintext": warnings_text,
-            "html": warnings_html,
-            "URL": mainpage_URL,
-        }
-        #  page_contents['page alerts'] = [warning.get_text() for warning in warnings if warnings]
-
-    # Look for subjects and split them by subtopic
-    topics = soup.find_all(
-        class_="frame frame-default frame-type-textmedia frame-layout-0"
-    )
-
-    for topic in topics:
-
-        # Look for headers in each subject
-        raw_title = None
-        if topic.find("h2"):
-            raw_title = topic.find("h2").contents[0]
-        if raw_title:
-            title = " ".join(raw_title.split())
-            links_plaintext = [href.get_text() for href in topic.find_all("a")]
-            page_contents[title] = {
-                "plaintext": links_plaintext,
-                "html": topic.prettify(),
-                "URL": mainpage_URL,
-            }
-
-    return page_contents
-
-
-def command_legacy():
-    """First version of the scraper, works unchanged."""
-
-    # faq page is different in structure so is parsed separately below.
-    french_URLS = [
-        "https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/situation-coronavirus-quebec/",
-        "https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/consignes-directives-contexte-covid-19/",
-        "https://www.quebec.ca/sante/problemes-de-sante/a-z/informations-generales-sur-le-coronavirus/",
-        "https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/stress-anxiete-et-deprime-associes-a-la-maladie-a-coronavirus-covid-19/",
-        "https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/consignes-directives-contexte-covid-19/communautes-autochtones/",
-        "https://www.quebec.ca/famille-et-soutien-aux-personnes/aide-et-soutien/allocation-directe-cheque-emploi-service-une-modalite-de-dispensation-des-services-de-soutien-a-domicile/",
-        "https://www.quebec.ca/famille-et-soutien-aux-personnes/aide-financiere/programme-aide-temporaire-aux-travailleurs/",
-        "https://www.quebec.ca/education/aide-financiere-aux-etudes/remboursement/",
-        "https://www.quebec.ca/famille-et-soutien-aux-personnes/services-de-garde-durgence/",
-        "https://www.quebec.ca/gouv/covid19-fonction-publique/",
-        "https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/fermeture-endroits-publics-commerces-services-covid19/",
-        "https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/informations-pour-les-femmes-enceintes-coronavirus-covid-19/",
-        "https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/informations-pour-les-parents-d-enfants-de-0-a-17-ans-coronavirus-covid-19/",
-    ]
-
-    # This is to have the files compatible with the Raza framework
-    # Note that content is being appended to the end of the .md files
-    # They need to be deleted if already present when generating them
-    # To generate the md files, switch convert_to_md to True
-    convert_to_md = False
-    responses_fr_fname = "covidfaq/scrape/responses_fr.md"
-    nlu_fr_fname = "covidfaq/scrape/nlu_fr.md"
-    responses_en_fname = "covidfaq/scrape/responses_en.md"
-    nlu_en_fname = "covidfaq/scrape/nlu_en.md"
-
-    # scrape the "regular pages" structures
-    for count, fr_URL in enumerate(french_URLS):
-        log.info("scraping", count=count)
-        en_URL = get_english_page(fr_URL)
-        page_contents_fr = get_page_contents(fr_URL)
-        page_contents_en = get_page_contents(en_URL)
-
-        page_to_json(page_contents_fr, "covidfaq/scrape/" + str(count) + "_fr.json")
-        page_to_json(page_contents_en, "covidfaq/scrape/" + str(count) + "_en.json")
-
-        if convert_to_md:
-            page_to_md(page_contents_fr, fr_URL, responses_fr_fname, nlu_fr_fname)
-            page_to_md(page_contents_en, en_URL, responses_en_fname, nlu_en_fname)
-
-    # scrape the faq
-    faq_URL_fr = "https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/reponses-questions-coronavirus-covid19/"
-    faq_URL_en = get_english_page(faq_URL_fr)
-    faq_contents_fr = get_faq_contents(faq_URL_fr)
-    faq_contents_en = get_faq_contents(faq_URL_en)
-    page_to_json(faq_contents_fr, "covidfaq/scrape/faq_fr.json")
-    page_to_json(faq_contents_en, "covidfaq/scrape/faq_en.json")
-
-    # scrape the main page
-    mainpage_URL_fr = (
-        "https://www.quebec.ca/sante/problemes-de-sante/a-z/coronavirus-2019/"
-    )
-    mainpage_URL_en = get_english_page(mainpage_URL_fr)
-    mainpage_contents_fr = get_mainpage_contents(mainpage_URL_fr)
-    mainpage_contents_en = get_mainpage_contents(mainpage_URL_en)
-
-    page_to_json(mainpage_contents_fr, "covidfaq/scrape/mainpage_fr.json")
-    page_to_json(mainpage_contents_en, "covidfaq/scrape/mainpage_en.json")
-
-
 def rule_nesting(soup, info, url, rule):
     exclude = rule["exclude"]
-    subjects = soup.select(rule["parent"])
     results = []
+
+    # Keep track of header levels (h1 - h4)
+    nested_titles = ['', '', '', '']
+    prev_nest_level = 0
+    # Get the main header of the page if it exists
+    main_title = soup.select('.d-block')
+    if main_title:
+        if main_title[0].name == 'h1':
+            nested_titles[0] = main_title[0].get_text()
+
+    subjects = soup.select(rule["parent"])
     for sub in subjects:
         title = sub.select_one(rule["title"]) if rule["title"] else True
         body = sub.select_one(rule["body"]) if rule["body"] else sub
-        if not title or not body:
-            continue
-
-        # Exclusions
-        if exclude["selector"] and sub.select_one(exclude["selector"]):
+        if not title:
             continue
 
         if title is True:
             raw_title = ""
         else:
             raw_title = title.get_text().strip()
+
+            if title.name in 'h1, h2, h3, h4':
+                nest_level = int(title.name[1]) - 1
+                if nest_level >= prev_nest_level:
+                    nested_titles[nest_level] = raw_title
+                    prev_nest_level = nest_level
+                else:
+                    nested_titles[nest_level] = raw_title
+                    for n in range(nest_level+1, len(nested_titles)):
+                        nested_titles[n] = ''
+
         if exclude["title"] and re.search(exclude["title"], raw_title):
             continue
+
+        if not body:
+            continue
+
+        # Exclusions
+        if exclude["selector"] and sub.select_one(exclude["selector"]):
+            continue
+
 
         raw_body = body.get_text().strip()
         if exclude["body"] and re.search(exclude["body"], raw_body):
             continue
 
         entry = {
+            "nested_title": nested_titles.copy(),
             "title": raw_title,
             "plaintext": [
                 elem.get_text() if isinstance(elem, bs4.Tag) else str(elem)

--- a/covidfaq/scrape/scrape.py
+++ b/covidfaq/scrape/scrape.py
@@ -23,13 +23,14 @@ def remove_html_tags(data):
 
 
 def soup_to_html(filename, soup):
-    with open(filename, "w", encoding='utf-8') as f:
+    with open(filename, "w", encoding="utf-8") as f:
         f.write(str(soup))
 
 
 def page_to_json(page_contents, fname):
     with open(fname, "w", encoding="utf-8") as fp:
         json.dump(page_contents, fp, indent=4, ensure_ascii=False)
+
 
 def page_to_md(page_contents, page_url, response_filename, nlu_filename):
     section_title = page_url.rsplit("/")[-2]
@@ -60,12 +61,12 @@ def rule_nesting(soup, info, url, rule):
     results = []
 
     # Keep track of header levels (h1 - h4)
-    nested_titles = ['', '', '', '']
+    nested_titles = ["", "", "", ""]
     prev_nest_level = 0
     # Get the main header of the page if it exists
-    main_title = soup.select('.d-block')
+    main_title = soup.select(".d-block")
     if main_title:
-        if main_title[0].name == 'h1':
+        if main_title[0].name == "h1":
             nested_titles[0] = main_title[0].get_text()
 
     subjects = soup.select(rule["parent"])
@@ -80,14 +81,14 @@ def rule_nesting(soup, info, url, rule):
         else:
             raw_title = title.get_text().strip()
 
-            if title.name in 'h1, h2, h3, h4':
+            if title.name in "h1, h2, h3, h4":
                 nest_level = int(title.name[1]) - 1
                 if nest_level >= prev_nest_level:
                     nested_titles[nest_level] = raw_title
                 else:
                     nested_titles[nest_level] = raw_title
-                    for n in range(nest_level+1, len(nested_titles)):
-                        nested_titles[n] = ''
+                    for n in range(nest_level + 1, len(nested_titles)):
+                        nested_titles[n] = ""
                 prev_nest_level = nest_level
 
         if exclude["title"] and re.search(exclude["title"], raw_title):
@@ -99,7 +100,6 @@ def rule_nesting(soup, info, url, rule):
         # Exclusions
         if exclude["selector"] and sub.select_one(exclude["selector"]):
             continue
-
 
         raw_body = body.get_text().strip()
         if exclude["body"] and re.search(exclude["body"], raw_body):
@@ -177,11 +177,10 @@ def extract_sections(url, info, cfg, translated=False):
     return results, soup
 
 
-
-def run(yaml_filename, outdir='covidfaq/scrape', formatting='old', site=None):
+def run(yaml_filename, outdir="covidfaq/scrape", formatting="old", site=None):
     """Scrape websites for information."""
 
-    with open(yaml_filename, 'r') as stream:
+    with open(yaml_filename, "r") as stream:
         sites = load(stream, Loader=yaml.FullLoader)
     now = str(datetime.now())
 
@@ -219,7 +218,6 @@ def run(yaml_filename, outdir='covidfaq/scrape', formatting='old', site=None):
             filename_html = os.path.join(outdir, filename + ".html")
             soup_to_html(filename_html, soup)
 
-
     elif formatting == "new":
         outfile = out or "scrape_results.json"
         page_to_json(results, outfile)
@@ -233,7 +231,9 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--sites", help="list of sites to scrape", required=True)
-    parser.add_argument("--outdir", help="where to save scrapes", default='covidfaq/scrape')
+    parser.add_argument(
+        "--outdir", help="where to save scrapes", default="covidfaq/scrape"
+    )
     args = parser.parse_args()
 
     run(args.sites, args.outdir)

--- a/scripts/scraper.py
+++ b/scripts/scraper.py
@@ -1,9 +1,6 @@
-import coleo
-
 from covidfaq.scrape import scrape
 from covidfaq.search import build_index
 
 if __name__ == "__main__":
-    with coleo.setvars(sites=coleo.ConfigFile("covidfaq/scrape/quebec-sites.yaml")):
-        scrape.run()
+    scrape.run("covidfaq/scrape/quebec-sites.yaml")
     build_index.run()


### PR DESCRIPTION
## Description
* Save the the entire .html page that was used to generate the .json (will be updated every time scrape is run, useful to have a point of reference every time we scrape since the site updates regularly). We now will have for example `quebec-fr-0.json` and `quebec-fr-0.html` saved.
* Removed Coleo (I don't see any added benefit to it and it made iterating harder)
* Cleaned up code that wasn't being used anymore in `scrape.py`
* Added an extra field to the .json files, `nested_headers`, which will collect, when available, the hierarchy of headers each section is associated to. For example, if a section is h3, it will also keep track of the last h2 and h1, and return [h1, h2, h3] for that section.


