### PR TITLE
chore: add pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Description
+
+<!-- Short summary of your changes. -->
+<!-- Add screenshots if needed (simple copy/paste or drag-n-drop will work). -->
+<!-- You can also leave notes for code reviewers here. -->
+
+## Related issues
+
+<!-- Pull requests should be related to open GitHub Issues. -->
+<!-- Please put all related issue IDs here: -->
+<!-- * #{issue-number} -->
+
+## Related changes
+
+<!-- What other PRs does this PR depend on? -->
+<!-- Please put references to other PRs here: -->
+<!-- * #{pr-number}  -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines <!-- `fix(content): typo in travel-restrictions` -->
+- [ ] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->


### PR DESCRIPTION
## Description

Add a pull request template to improve the contributing experience.

Overrides company-white template that contains internal workflows not related to an open-source project.

## Checklist

- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines  <!-- `fix(content): typo in travel-restrictions` -->
- [x] All relevant PR sections are populated, irrelevant ones are removed <!-- Those sections help reviewers better understand what the PR is about. -->
