### PR TITLE
feat: Remove isort from ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ workflows:
       - python/black:
           name: black
           context: org-global-v2
-      - python/isort:
-          name: isort
-          context: org-global-v2
+      # - python/isort:
+      #     name: isort
+      #     context: org-global-v2
       - python/test:
           name: test
           before_tests_steps:
@@ -40,7 +40,7 @@ workflows:
           requires:
             - pylama
             - black
-            - isort
+            # - isort
             - test
           context: org-global-v2
       - app/build:


### PR DESCRIPTION
## Description

A bunch of deploys on the CI were failing because of isort and could not be reproduced locally. This removes isort out of the pipeline for now until this can be figured out.